### PR TITLE
oneplus2: Use xxhdpi dalvik heap values

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -61,7 +61,7 @@ PRODUCT_PACKAGES += \
 TARGET_SCREEN_HEIGHT := 1920
 TARGET_SCREEN_WIDTH := 1080
 
-$(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hwui.texture_cache_size=72 \


### PR DESCRIPTION
Currently, we have seen some native crashes related to gralloc on startup. It is
because the minimum dalvik VM size is too low and it crashes many apps like
Nova launcher and Alipay when memory pressure is high.

Use xxhdpi config from Lineage to fix this. No crashes after this tune.